### PR TITLE
Update list of releases by 2021

### DIFF
--- a/index.asciidoc
+++ b/index.asciidoc
@@ -21,22 +21,63 @@ heterogeneous environments via a common framework and APIs.
 
 == Recent Updates
 
-- May 27th, 2021: Released IPM2 Editions version 2.3.0 as x86_64 OVA virtual appliance and software update packages
+- May 27th, 2021: Released IPM2 Editions version 2.3.0
+  as x86_64 OVA virtual appliance and software update packages
+  built from 42ITy(TM) source-code
   * More details at link:https://github.com/42ity/release-note/blob/release/IPM-2.3.0/ipm/2.3.0.md[Release notes for IPM-2.3.0]
-- February 3rd, 2021: Released IPM2 Editions version 2.2.0 as x86_64 OVA virtual appliance and software update packages
+- February 3rd, 2021: Released IPM2 Editions version 2.2.0
+  as x86_64 OVA virtual appliance and software update packages
+  built from 42ITy(TM) source-code
   * More details at link:https://github.com/42ity/release-note/blob/release/IPM-2.3.0/ipm/2.2.0.md[Release notes for IPM-2.2.0]
-- November 11th, 2020: Released IPM2 Editions service pack version 2.1.0-2 as x86_64 OVA virtual appliance and software update packages
-- August 3rd, 2020: Released IPM2 Editions service pack version 2.1.0-1 as x86_64 OVA virtual appliance and software update packages
-- June 24th, 2020: Previously marketed IPC3000 hardware appliances officially discontinued due to original device model EOL; existing deployments with IPM Infra supported with a migration path into IPM2
-- June 11th, 2020: Released IPM2 Editions version 2.1.0 as x86_64 OVA virtual appliance and software update packages
-- October 24th, 2019: Released IPM2 Editions version 2.0.1 as x86_64 OVA virtual appliance and software update packages
-- September 23rd, 2019: Released IPM2 Editions version 2.0.0 as x86_64 OVA virtual appliance and software update packages
-- April 8th, 2019: Updated firmware and software for the Intelligent Power Controller appliance, built from 42ITy(TM) source-code, was released as Eaton IPM Infra version 1.5.0, and introducing officially supported builds of x86_64 OVA virtual appliances.
-- October 25th, 2018: Updated firmware and software for the Intelligent Power Controller appliance, built from 42ITy(TM) source-code, was released as Eaton IPM Infra version 1.4.2.
-- September 24th, 2018: Updated firmware and software for the Intelligent Power Controller appliance, built from 42ITy(TM) source-code, was released and made generally downloadable at link:http://www.eaton.eu/ipminfrastructure[Eaton IPM Infra version 1.4.1].
-- July 11th, 2018: Updated firmware and software for the Intelligent Power Controller appliance, built from 42ITy(TM) source-code, was released as Eaton IPM Infra version 1.4.0.
-- January 25th, 2018: Updated firmware and software for the Intelligent Power Controller appliance, built from 42ITy(TM) source-code, was released as Eaton IPM Infra version 1.3.0.
-- July 31st, 2017: Updated firmware and software for the Intelligent Power Controller appliance, built from 42ITy(TM) source-code, was released and made generally downloadable at link:http://www.eaton.eu/ipminfrastructure[Eaton IPM Infra version 1.2.0].
+- November 11th, 2020: Released IPM2 Editions service pack version 2.1.0-2
+  as x86_64 OVA virtual appliance and software update packages
+  built from 42ITy(TM) source-code
+- August 3rd, 2020: Released IPM2 Editions service pack version 2.1.0-1
+  as x86_64 OVA virtual appliance and software update packages
+  built from 42ITy(TM) source-code
+- June 24th, 2020: Previously marketed IPC3000 hardware appliances were
+  officially discontinued due to original device model EOL; existing
+  deployments with IPM Infra supported with a migration path into IPM2
+- June 11th, 2020: Released IPM2 Editions version 2.1.0
+  as x86_64 OVA virtual appliance and software update packages
+  built from 42ITy(TM) source-code
+- October 24th, 2019: Released IPM2 Editions version 2.0.1
+  as x86_64 OVA virtual appliance and software update packages
+- September 23rd, 2019: Released Eaton IPM2 Editions version 2.0.0 as
+  x86_64 OVA virtual appliance and software update packages,
+  built from 42ITy(TM) source-code and available through the common
+  link:https://www.eaton.com/us/en-us/catalog/backup-power-ups-surge-it-power-distribution/eaton-intelligent-power-manager.html[Eaton
+  Intelligent Power Manager] product family site
+- April 8th, 2019: Updated firmware and software for the
+  Intelligent Power Controller appliance, built from 42ITy(TM) source-code,
+  was released as Eaton IPM Infra version 1.5.0, and introducing officially
+  supported builds of x86_64 OVA virtual appliances, and made generally
+  downloadable as
+  link:http://www.eaton.eu/ipminfrastructure[Eaton
+  Intelligent Power Manager Infrastructure Understand Edition].
+- October 25th, 2018: Updated firmware and software for the
+  Intelligent Power Controller appliance, built from 42ITy(TM) source-code,
+  was released as Eaton IPM Infra version 1.4.2.
+- September 24th, 2018: Updated firmware and software for the
+  Intelligent Power Controller appliance, built from 42ITy(TM) source-code,
+  was released as Eaton IPM Infra version 1.4.1, and made generally
+  downloadable as
+  link:http://www.eaton.eu/ipminfrastructure[Eaton
+  Intelligent Power Manager Infrastructure Understand Edition].
+- July 11th, 2018: Updated firmware and software for the
+  Intelligent Power Controller appliance, built from 42ITy(TM) source-code,
+  was released as Eaton IPM Infra version 1.4.0.
+- January 25th, 2018: Updated firmware and software for the
+  Intelligent Power Controller appliance, built from 42ITy(TM) source-code,
+  was released as Eaton IPM Infra version 1.3.0.
+- July 31st, 2017: Updated firmware and software for the
+  Intelligent Power Controller appliance, built from 42ITy(TM) source-code,
+  was released and made generally downloadable as
+  link:http://www.eaton.eu/ipminfrastructure[Eaton
+  Intelligent Power Manager Infrastructure Understand Edition]
 - February 8th, 2017: 42ITy(TM) source-code and updated website availability.
 - October 5th, 2016: Initial announcement of 42ITy(TM) availability.
-- October 5th, 2016: Initial announcement of link:http://www.eaton.eu/ipminfrastructure[Eaton Intelligent Power Management Infrastructure and Intelligent Power Controller] availability.
+- October 5th, 2016: Initial announcement of
+  link:http://www.eaton.eu/ipminfrastructure[Eaton
+  Intelligent Power Management Infrastructure and Intelligent Power Controller]
+  availability.

--- a/index.asciidoc
+++ b/index.asciidoc
@@ -22,9 +22,9 @@ heterogeneous environments via a common framework and APIs.
 == Recent Updates
 
 - May 27th, 2021: Released IPM2 Editions version 2.3.0 as x86_64 OVA virtual appliance and software update packages
-  * More details at https://github.com/42ity/release-note/blob/release/IPM-2.3.0/ipm/2.3.0.md
+  * More details at link:https://github.com/42ity/release-note/blob/release/IPM-2.3.0/ipm/2.3.0.md[Release notes for IPM-2.3.0]
 - February 3rd, 2021: Released IPM2 Editions version 2.2.0 as x86_64 OVA virtual appliance and software update packages
-  * More details at https://github.com/42ity/release-note/blob/release/IPM-2.3.0/ipm/2.2.0.md
+  * More details at link:https://github.com/42ity/release-note/blob/release/IPM-2.3.0/ipm/2.2.0.md[Release notes for IPM-2.2.0]
 - November 11th, 2020: Released IPM2 Editions service pack version 2.1.0-2 as x86_64 OVA virtual appliance and software update packages
 - August 3rd, 2020: Released IPM2 Editions service pack version 2.1.0-1 as x86_64 OVA virtual appliance and software update packages
 - June 24th, 2020: Previously marketed IPC3000 hardware appliances officially discontinued due to original device model EOL; existing deployments with IPM Infra supported with a migration path into IPM2


### PR DESCRIPTION
Line-wrap long entries, update Eaton URLs and links, and note that IPM2 is also based on 42ITy(TM)

Expected to get rendered as seen at https://github.com/jimklimov/42ity-org-website/blob/releases-by-2021/index.asciidoc